### PR TITLE
actualizando el coretype de field string

### DIFF
--- a/bungiesearch/fields.py
+++ b/bungiesearch/fields.py
@@ -107,7 +107,8 @@ class AbstractField(object):
 
 # All the following definitions could probably be done with better polymorphism.
 class StringField(AbstractField):
-    coretype = 'string'
+    # The [string] type is deprecated, please use [text] or [keyword] in 5.x
+    coretype = ['text', 'keyword']
     fields = ['doc_values', 'term_vector', 'norms', 'index_options', 'analyzer', 'index_analyzer', 'search_analyzer', 'include_in_all', 'ignore_above', 'position_offset_gap', 'fielddata', 'similarity']
 
     def value(self, obj):


### PR DESCRIPTION
Al no responder correctamente a los query a elasticsearch con `term` he revisado y el bungiesearch.fields.StringField tiene coretype = 'string', este tipo en elasticsear para el 5.4.1 que estoy usando es depracated, le he hecho el mapping a mano y este ha sido le warning:
`#! Deprecation: The [string] field is deprecated, please use [text] or [keyword] instead on [desc]`
Creo que con este cambio soluciono el problema. 